### PR TITLE
Changes to support api-version updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.ruby",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "The Ruby extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/src/azure/CodeGeneratorRba.cs
+++ b/src/azure/CodeGeneratorRba.cs
@@ -26,6 +26,17 @@ namespace AutoRest.Ruby.Azure
         /// Gets the usage instructions for the code generator.
         /// </summary>
         public override string UsageInstructions => @"The ""gem 'ms_rest_azure' ~> 0.7"" is required for working with generated code.";
+        
+        /// <summary>
+        /// Name of the generated sub-folder inside output directory (private property).
+        /// </summary>
+        private string generatedFolderName = "generated";
+        
+        /// <summary>
+        /// Name of the generated sub-folder inside output directory.
+        /// </summary>
+        protected override string GeneratedFolderName { get { return generatedFolderName; } set { generatedFolderName = value; } }
+
 
         /// <summary>
         /// Generates Ruby code for Azure service client.
@@ -35,6 +46,7 @@ namespace AutoRest.Ruby.Azure
         public override async Task Generate(CodeModel cm)
         {
             var codeModel = cm as CodeModelRba;
+            generatedFolderName = Path.Combine(codeModel.ApiVersion, "generated");
             if (codeModel == null)
             {
                 throw new InvalidCastException("CodeModel is not a Azure Ruby code model.");

--- a/src/azure/CodeGeneratorRba.cs
+++ b/src/azure/CodeGeneratorRba.cs
@@ -49,7 +49,7 @@ namespace AutoRest.Ruby.Azure
             if (codeModel.ApiVersion == null){
                 throw new NullReferenceException("CodeModel doesn't have api-version set, specs in code model have mismatching api-versions.");
             }
-            generatedFolderName = Path.Combine(codeModel.ApiVersion, "generated");
+            generatedFolderName = Path.Combine(codeModel.ApiVersion, generatedFolderName);
             if (codeModel == null)
             {
                 throw new InvalidCastException("CodeModel is not a Azure Ruby code model.");

--- a/src/azure/CodeGeneratorRba.cs
+++ b/src/azure/CodeGeneratorRba.cs
@@ -31,7 +31,7 @@ namespace AutoRest.Ruby.Azure
         /// Name of the generated sub-folder inside output directory (private property).
         /// </summary>
         private string generatedFolderName = "generated";
-        
+
         /// <summary>
         /// Name of the generated sub-folder inside output directory.
         /// </summary>
@@ -46,6 +46,9 @@ namespace AutoRest.Ruby.Azure
         public override async Task Generate(CodeModel cm)
         {
             var codeModel = cm as CodeModelRba;
+            if (codeModel.ApiVersion == null){
+                throw new NullReferenceException("CodeModel doesn't have api-version set, specs in code model have mismatching api-versions.");
+            }
             generatedFolderName = Path.Combine(codeModel.ApiVersion, "generated");
             if (codeModel == null)
             {

--- a/src/azure/Model/RequirementsRba.cs
+++ b/src/azure/Model/RequirementsRba.cs
@@ -14,6 +14,11 @@ namespace AutoRest.Ruby.Azure.Model
     class RequirementsRba : RequirementsRb
     {
         /// <summary>
+        /// Name of the generated sub-folder inside output directory.
+        /// </summary>
+        protected override string GeneratedFolderName { get { return this.CodeModel.ApiVersion + "/generated"; } }
+        
+        /// <summary>
         /// Checks whether model should be excluded from producing.
         /// </summary>
         /// <param name="model">The model.</param>

--- a/src/vanilla/CodeGeneratorRb.cs
+++ b/src/vanilla/CodeGeneratorRb.cs
@@ -20,9 +20,9 @@ namespace AutoRest.Ruby
     public class CodeGeneratorRb : CodeGenerator
     {
         /// <summary>
-        ///     Name of the generated sub-folder inside ourput directory.
+        ///     Name of the generated sub-folder inside output directory.
         /// </summary>
-        private const string GeneratedFolderName = "generated";
+        protected virtual string GeneratedFolderName { get { return "generated"; } set { GeneratedFolderName = value; } }
 
         /// <summary>
         ///     Gets the file extension of the generated code files.

--- a/src/vanilla/Model/RequirementsRb.cs
+++ b/src/vanilla/Model/RequirementsRb.cs
@@ -19,14 +19,14 @@ namespace AutoRest.Ruby.Model
     public class RequirementsRb
     {
         /// <summary>
-        /// Name of the generated sub-folder inside ourput directory.
+        /// Name of the generated sub-folder inside output directory.
         /// </summary>
-        private const string GeneratedFolderName = "generated";
+        protected virtual string GeneratedFolderName { get { return "generated"; } }
 
         /// <summary>
         /// Format for the autoload module.
         /// </summary>
-        private const string AutoloadFormat = "autoload :{0},{1}'" + GeneratedFolderName + "/{2}/{3}'";
+        private string AutoloadFormat { get { return "autoload :{0},{1}'" + GeneratedFolderName + "/{2}/{3}'"; } }
 
         /// <summary>
         /// Number of spaces between class name and file name required for better readability.

--- a/test/azure/RspecTests/azure_report_spec.rb
+++ b/test/azure/RspecTests/azure_report_spec.rb
@@ -2,7 +2,7 @@
 
 $: << 'RspecTests/Generated/azure_report'
 
-require 'generated/azure_report'
+require '1.0.0/generated/azure_report'
 
 include AzureReportModule
 

--- a/test/azure/RspecTests/azure_special_properties_spec.rb
+++ b/test/azure/RspecTests/azure_special_properties_spec.rb
@@ -5,7 +5,7 @@ $: << 'RspecTests/Generated/azure_special_properties'
 require 'rspec'
 require 'securerandom'
 
-require 'generated/azure_special_properties'
+require '2015-07-01-preview/generated/azure_special_properties'
 
 include AzureSpecialPropertiesModule
 

--- a/test/azure/RspecTests/azure_url_spec.rb
+++ b/test/azure/RspecTests/azure_url_spec.rb
@@ -5,7 +5,7 @@ $: << 'RspecTests/Generated/azure_url'
 require 'rspec'
 require 'securerandom'
 
-require 'generated/subscription_id_api_version'
+require '2014-04-01-preview/generated/subscription_id_api_version'
 
 include AzureUrlModule
 

--- a/test/azure/RspecTests/head_exception_spec.rb
+++ b/test/azure/RspecTests/head_exception_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/head_exceptions'
 
 require 'rspec'
-require 'generated/head_exceptions'
+require '1.0.0/generated/head_exceptions'
 
 include HeadExceptionsModule
 

--- a/test/azure/RspecTests/head_spec.rb
+++ b/test/azure/RspecTests/head_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/head'
 
 require 'rspec'
-require 'generated/head'
+require '1.0.0/generated/head'
 
 include HeadModule
 

--- a/test/azure/RspecTests/lro_spec.rb
+++ b/test/azure/RspecTests/lro_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/lro'
 
 require 'rspec'
-require 'generated/lro'
+require '1.0.0/generated/lro'
 
 include LroModule
 include LroModule::Models

--- a/test/azure/RspecTests/models_generation_and_inheritance_spec.rb
+++ b/test/azure/RspecTests/models_generation_and_inheritance_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/azure_resource_inheritance'
 
 require 'rspec'
-require 'generated/resource_inheritance'
+require '1.0.0/generated/resource_inheritance'
 
 include AzureResourceInheritanceModule
 

--- a/test/azure/RspecTests/odata_type_property_spec.rb
+++ b/test/azure/RspecTests/odata_type_property_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/odata_type_property'
 
 require 'rspec'
-require 'generated/odata_type_property'
+require '1.0.0/generated/odata_type_property'
 
 include AzureODataTypePropertyModule
 

--- a/test/azure/RspecTests/paging_spec.rb
+++ b/test/azure/RspecTests/paging_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/paging'
 
 require 'rspec'
-require 'generated/paging'
+require '1.0.0/generated/paging'
 
 include PagingModule
 

--- a/test/azure/RspecTests/parameter_grouping_spec.rb
+++ b/test/azure/RspecTests/parameter_grouping_spec.rb
@@ -3,7 +3,7 @@
 $: << 'RspecTests/Generated/parameter_grouping'
 
 require 'rspec'
-require 'generated/azure_parameter_grouping'
+require '1.0.0/generated/azure_parameter_grouping'
 
 include ParameterGroupingModule
 include ParameterGroupingModule::Models


### PR DESCRIPTION
Updates to support changes for generation with multi-api-version published at https://github.com/veronicagg/azure-sdk-for-ruby/tree/3bc168dd4a9aa2d5a2d5c3272ec2847c7bc8168f/management
Related to https://github.com/Azure/azure-sdk-for-ruby/issues/879 and https://github.com/Azure/azure-sdk-for-ruby/issues/880

Since we're adding api-version in lib folder, I've updated the paths where files get generated to use the api-version and the references to those paths in the code - particularly lib/generated/azure_mgmt_*.rb (for autoloads and require of module_definition) - https://github.com/veronicagg/azure-sdk-for-ruby/blob/3bc168dd4a9aa2d5a2d5c3272ec2847c7bc8168f/management/azure_mgmt_resources/lib/2017-05-10/generated/azure_mgmt_resources.rb#L23