### PR TITLE
Code changes to remove condition to check for known primary type

### DIFF
--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -191,19 +191,6 @@ namespace AutoRest.Ruby
                 return parameter.Name;
             }
 
-            PrimaryType primaryType = sequence.ElementType as PrimaryType;
-            EnumType enumType = sequence.ElementType as EnumType;
-            if (enumType != null && enumType.ModelAsString)
-            {
-                primaryType = New<PrimaryType>(KnownPrimaryType.String);
-            }
-
-            if (primaryType == null)
-            {
-                throw new InvalidOperationException(
-                    "Cannot generate a formatted sequence from a " + $"null parameter {parameter}");
-            }
-
             return string.Format("{0}.nil? ? nil : {0}.join('{1}')", parameter.Name, parameter.CollectionFormat.GetSeparator());
         }
 

--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -198,10 +198,10 @@ namespace AutoRest.Ruby
                 primaryType = New<PrimaryType>(KnownPrimaryType.String);
             }
 
-            if (primaryType == null || primaryType.KnownPrimaryType != KnownPrimaryType.String)
+            if (primaryType == null)
             {
                 throw new InvalidOperationException(
-                    "Cannot generate a formatted sequence from a " + $"non-string array parameter {parameter}");
+                    "Cannot generate a formatted sequence from a " + $"null parameter {parameter}");
             }
 
             return string.Format("{0}.nil? ? nil : {0}.join('{1}')", parameter.Name, parameter.CollectionFormat.GetSeparator());

--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -179,7 +179,7 @@ namespace AutoRest.Ruby
         }
 
         /// <summary>
-        /// Format the value of a sequence given the modeled element format. Note that only sequences of strings are supported.
+        /// Format the value of a sequence given the modeled element format.
         /// </summary>
         /// <param name="parameter">The parameter to format.</param>
         /// <returns>A reference to the formatted parameter value.</returns>


### PR DESCRIPTION
When you execute the following command, you get the error:

```
C:\workspace\autorest.ruby>autorest https://raw.githubusercontent.com/Azure/azure-rest-api-specs/current/specification/trafficmanager/resource-manager/readme.md --output-folder=C:\workspace\temp --azure-arm=True --namespace=Azure::ARM::TrafficManager --package-name=azure_mgmt_traffic_manager --package-version=0.11.0 --ruby
AutoRest code generation utility.

(C) 2017 Microsoft Corporation.
https://aka.ms/autorest
Loading AutoRest extension '@microsoft.azure/autorest.ruby' (1.9.3)
Loading AutoRest extension '@microsoft.azure/autorest.modeler' (1.9.6)
FATAL: System.InvalidOperationException: Cannot generate a formatted sequence from a non-string array parameter AutoRest.Ruby.Model.ParameterRb
   at AutoRest.Ruby.ClientModelExtensions.GetFormattedReferenceValue(Parameter parameter) in C:\work\oneautorest\autorest.ruby\src\vanilla\ClientModelExtensions.cs:line 207
........
........
```

This error is happening because of a condition that was added (and removed in the current PR). Now, after modification, when you execute the command, the SDK is generated without any issues:

```
C:\workspace\autorest.ruby>autorest https://raw.githubusercontent.com/Azure/azure-rest-api-specs/current/specification/trafficmanager/resource-manager/readme.md --output-folder=C:\workspace\temp --azure-arm=True --namespace=Azure::ARM::TrafficManager --package-name=azure_mgmt_traffic_manager --package-version=0.11.0 --ruby --use=C:\workspace\autorest.ruby
AutoRest code generation utility.

(C) 2017 Microsoft Corporation.
https://aka.ms/autorest
Loading local AutoRest extension '@microsoft.azure/autorest.ruby' (C:\workspace\autorest.ruby)
Loading AutoRest extension '@microsoft.azure/autorest.modeler' (1.9.6)
```