### PR TITLE
[In Review] Updating the inheritance logic for Resource & SubResource for azure-arm Ruby generator

### DIFF
--- a/.gulp/regeneration.iced
+++ b/.gulp/regeneration.iced
@@ -94,6 +94,10 @@ rubyAzureMappings = {
   'parameter_grouping':['azure-parameter-grouping.json', 'ParameterGroupingModule']
 }
 
+rubyAzureAdditionalMappings = {
+  'azure_resource_inheritance': ['resource_inheritance.json', 'AzureResourceInheritanceModule']
+}
+
 swaggerDir = "node_modules/@microsoft.azure/autorest.testserver/swagger"
 
 task 'regenerate-rubyazure', '', (done) ->
@@ -101,6 +105,20 @@ task 'regenerate-rubyazure', '', (done) ->
     'outputBaseDir': 'test/azure',
     'inputBaseDir': swaggerDir,
     'mappings': rubyAzureMappings,
+    'outputDir': 'RspecTests/Generated',
+    'language': 'ruby',
+    'azureArm': true,
+    'nsPrefix': 'MyNamespace'
+  },done
+  return null
+
+testSwaggerDir = "test/swagger"
+
+task 'regenerate-rubyazure-additional', '', (done) ->
+  regenExpected {
+    'outputBaseDir': 'test/azure',
+    'inputBaseDir': testSwaggerDir,
+    'mappings': rubyAzureAdditionalMappings,
     'outputDir': 'RspecTests/Generated',
     'language': 'ruby',
     'azureArm': true,
@@ -119,5 +137,5 @@ task 'regenerate-ruby', '', (done) ->
   },done
   return null
 
-task 'regenerate', "regenerate expected code for tests", ['regenerate-ruby', 'regenerate-rubyazure'], (done) ->
+task 'regenerate', "regenerate expected code for tests", ['regenerate-ruby', 'regenerate-rubyazure', 'regenerate-rubyazure-additional'], (done) ->
   done();

--- a/src/azure/Model/CompositeTypeRba.cs
+++ b/src/azure/Model/CompositeTypeRba.cs
@@ -51,7 +51,7 @@ namespace AutoRest.Ruby.Azure.Model
                 if (this.BaseModelType.Extensions.ContainsKey(AzureExtensions.ExternalExtension) ||
                     this.BaseModelType.Extensions.ContainsKey(AzureExtensions.AzureResourceExtension))
                 {
-                    if (!resourceOrSubResourceRegEx.IsMatch(typeName) || !IsResourceModelMatchingStandardDefinition(this))
+                    if (resourceOrSubResourceRegEx.IsMatch(typeName) || IsResourceModelMatchingStandardDefinition(this))
                     {
                         typeName = "MsRestAzure::" + typeName;
                     }
@@ -68,22 +68,21 @@ namespace AutoRest.Ruby.Azure.Model
         }
 
         /// <summary>
-        /// Checks if the provided definition of models 'Resource'/'SubResource' matches the standard definition,
-        /// as defined in MsRestAzure. For other models, it returns false.
+        /// Checks if the provided definition of model matches the standard definition of 'Resource'/'SubResource',
+        /// as defined in MsRestAzure.
         /// </summary>
-        /// <param name="model">to be validated</param>
-        /// <returns></returns>
+        /// <param name="model">CompositeType model to be validated.</param>
+        /// <returns><c>true</c> if model matches standard name and definition of Resource or SubResource, <c>false</c> otherwise.</returns>
         public static bool IsResourceModelMatchingStandardDefinition(CompositeType model)
         {
             string modelName = model.Name.ToString();
-            if (modelName.EqualsIgnoreCase("SubResource") &&
-                model.Properties.All(property => subResourceRegEx.IsMatch(property.Name.ToString())))
+            if (!resourceOrSubResourceRegEx.IsMatch(modelName))
             {
-                return true;
+                return false;
             }
 
-            if(modelName.EqualsIgnoreCase("Resource") &&
-               model.Properties.All(property => resourceRegEx.IsMatch(property.Name.ToString())))
+            if (model.Properties.All(property => subResourceRegEx.IsMatch(property.Name.ToString())) || 
+                model.Properties.All(property => resourceRegEx.IsMatch(property.Name.ToString())))
             {
                 return true;
             }

--- a/test/azure/RspecTests/resource_inheritance.rb
+++ b/test/azure/RspecTests/resource_inheritance.rb
@@ -1,0 +1,57 @@
+# encoding: utf-8
+
+$: << 'RspecTests/Generated/azure_resource_inheritance'
+
+require 'rspec'
+require 'generated/resource_inheritance'
+
+include AzureResourceInheritanceModule
+
+describe 'ResourceInheritance' do
+  before(:all) do
+    @base_url = ENV['StubServerURI']
+
+    dummyToken = 'dummy12321343423'
+    @credentials = MsRest::TokenCredentials.new(dummyToken)
+
+    @client = AzureResourceInheritanceTest.new(@credentials, @base_url)
+  end
+
+  it 'should generate expected resource models' do
+    modules = Module.const_get('AzureResourceInheritanceModule::Models')
+
+    # Should generate AzureResource class
+    azure_resource = modules.const_get('AzureResource')
+    expect(azure_resource.is_a?(Class)).to be_truthy
+
+    # Should generate LikeAzureResource class
+    like_azure_resource = modules.const_get('LikeAzureResource')
+    expect(like_azure_resource.is_a?(Class)).to be_truthy
+
+    # Should generate AzureResourceAdditionaProperties class
+    azure_resource_additional_properties = modules.const_get('AzureResourceAdditionaProperties')
+    expect(azure_resource_additional_properties.is_a?(Class)).to be_truthy
+
+    # Should not generate Resource class
+    expect { modules.const_get('Resource') }.to raise_error(NameError)
+  end
+
+  it 'should generate models with expected inheritance' do
+    modules = Module.const_get('AzureResourceInheritanceModule::Models')
+
+    # Should generate InheritMsRestAzureResource with super class as MsRestAzure::Resource
+    inherit_ms_rest_azure_resource = modules.const_get('InheritMsRestAzureResource')
+    expect(inherit_ms_rest_azure_resource.is_a?(Class)).to be_truthy
+    expect(inherit_ms_rest_azure_resource.superclass.name).to eq('MsRestAzure::Resource')
+
+    # Should generate InheritAzureResource with super class as AzureResource
+    inherit_azure_resource = modules.const_get('InheritAzureResource')
+    expect(inherit_azure_resource.is_a?(Class)).to be_truthy
+    expect(inherit_azure_resource.superclass.name).to eq('AzureResourceInheritanceModule::Models::AzureResource')
+
+    # Should generate InheritAzureResourceAdditionaProperties with super class as AzureResourceAdditionaProperties
+    azure_resource_additional_properties = modules.const_get('InheritAzureResourceAdditionaProperties')
+    expect(azure_resource_additional_properties.is_a?(Class)).to be_truthy
+    expect(azure_resource_additional_properties.superclass.name).to eq('AzureResourceInheritanceModule::Models::AzureResourceAdditionaProperties')
+  end
+end

--- a/test/swagger/resource_inheritance.json
+++ b/test/swagger/resource_inheritance.json
@@ -1,0 +1,335 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Azure Resource Inheritance Test",
+    "description": "Test Resource and SubResource inheritance.",
+    "version": "1.0.0"
+  },
+  "host": "localhost",
+  "schemes": [
+    "http"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/fakepath/{subscriptionId}/{resourceGroupName}/{id}?api-version={apiVersion}": {
+      "get": {
+        "operationId": "validationOfMethodParameters",
+        "summary": "",
+        "description": "Validates input parameters on the method. See swagger for details.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParamterer"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.",
+            "required": true,
+            "type": "string",
+            "maxLength": 10,
+            "minLength": 3,
+            "pattern": "[a-zA-Z0-9]+"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Required int multiple of 10 from 100 to 1000.",
+            "required": true,
+            "type": "integer",
+            "multipleOf": 10,
+            "maximum": 1000,
+            "minimum": 100
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "tags": [
+          "Redis"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of caches",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product": {
+      "description": "The product documentation.",
+      "required": [
+        "child",
+        "constString",
+        "constInt",
+        "constChild"
+      ],
+      "properties": {
+        "display_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Non required array of unique items from 0 to 6 elements.",
+          "maxItems": 6,
+          "uniqueItems": true,
+          "minItems": 0
+        },
+        "capacity": {
+          "type": "integer",
+          "description": "Non required int betwen 0 and 100 exclusive.",
+          "exclusiveMinimum": true,
+          "exclusiveMaximum": true,
+          "maximum": 100,
+          "minimum": 0
+        },
+        "image": {
+          "type": "string",
+          "description": "Image URL representing the product.",
+          "pattern": "http://\\w+"
+        },
+        "child": {
+          "$ref": "#/definitions/ChildProduct"
+        },
+        "constChild": {
+          "$ref": "#/definitions/ConstantProduct"
+        },
+        "constInt": {
+          "type": "integer",
+          "description": "Constant int",
+          "enum": [
+            0
+          ]
+        },
+        "constString": {
+          "type": "string",
+          "description": "Constant string",
+          "enum": [
+            "constant"
+          ]
+        },
+        "constStringAsEnum": {
+          "type": "string",
+          "description": "Constant string as Enum",
+          "enum": [
+            "constant_string_as_enum"
+          ],
+          "x-ms-enum": {
+            "name": "EnumConst",
+            "modelAsString": false
+          }
+        }
+      }
+    },
+    "ChildProduct": {
+      "description": "The product documentation.",
+      "required": [
+        "constProperty"
+      ],
+      "properties": {
+        "constProperty": {
+          "type": "string",
+          "description": "Constant string",
+          "enum": [
+            "constant"
+          ]
+        },
+        "count": {
+          "type": "integer",
+          "description": "Count"
+        }
+      }
+    },
+    "ConstantProduct": {
+      "description": "The product documentation.",
+      "required": [
+        "constProperty",
+        "constProperty2"
+      ],
+      "properties": {
+        "constProperty": {
+          "type": "string",
+          "description": "Constant string",
+          "enum": [
+            "constant"
+          ]
+        },
+        "constProperty2": {
+          "type": "string",
+          "description": "Constant string2",
+          "enum": [
+            "constant2"
+          ]
+        }
+      }
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "string"
+        }
+      }
+    },
+    "Resource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource. Ex- Microsoft.Compute/virtualMachines or Microsoft.Storage/storageAccounts."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "LikeAzureResource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource. Ex- Microsoft.Compute/virtualMachines or Microsoft.Storage/storageAccounts."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "AzureResource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource. Ex- Microsoft.Compute/virtualMachines or Microsoft.Storage/storageAccounts."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "AzureResourceAdditionaProperties": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the resource"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of the resource. Ex- Microsoft.Compute/virtualMachines or Microsoft.Storage/storageAccounts."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind of the resource."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "InheritMsRestAzureResource": {
+      "properties": {
+        "foo": {
+          "type": "string",
+          "description": "Property foo"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ]
+    },
+    "InheritAzureResource": {
+      "properties": {
+        "foo": {
+          "type": "string",
+          "description": "Property foo"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureResource"
+        }
+      ]
+    },
+    "InheritAzureResourceAdditionaProperties": {
+      "properties": {
+        "foo": {
+          "type": "string",
+          "description": "Property foo"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureResourceAdditionaProperties"
+        }
+      ]
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParamterer": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "ApiVersionParameter": {
+      "name": "apiVersion",
+      "in": "query",
+      "description": "Required string following pattern \\d{2}-\\d{2}-\\d{4}",
+      "required": true,
+      "type": "string",
+      "pattern": "\\d{2}-\\d{2}-\\d{4}"
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-ruby/issues/957 

We'll inherit from the `MsRestAzure::Resource` or  `MsRestAzure::SubResource`, when either name matches the regular expression or we determine that name matches and model has all properties standard properties. 

