### PR TITLE
Removing version file for azure generation, updating telemetry to use…

### DIFF
--- a/src/azure/CodeGeneratorRba.cs
+++ b/src/azure/CodeGeneratorRba.cs
@@ -88,13 +88,6 @@ namespace AutoRest.Ruby.Azure
             var requirementsTemplate = new RequirementsTemplate{Model = new RequirementsRba(codeModel, this)};
             await Write(requirementsTemplate, CodeNamer.UnderscoreCase(GeneratorSettingsRb.Instance.packageName ?? GeneratorSettingsRb.Instance.sdkName) + ImplementationFileExtension);
 
-            // Version File
-            if (GeneratorSettingsRb.Instance.packageVersion != null)
-            {
-                var versionTemplate = new VersionTemplate { Model = GeneratorSettingsRb.Instance.packageVersion };
-                await Write(versionTemplate, Path.Combine(GeneratorSettingsRb.Instance.sdkPath, "version" + ImplementationFileExtension));
-            }
-
             // Module Definition File
             if (Settings.Instance.Namespace != null)
             {

--- a/src/vanilla/Templates/ServiceClientTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientTemplate.cshtml
@@ -154,9 +154,10 @@ module @Settings.Namespace
     #
     def add_telemetry
         sdk_information = '@GeneratorSettingsRb.Instance.sdkPath'
-        if defined? @Settings.Namespace::VERSION
-          sdk_information = "#{sdk_information}/#{@Settings.Namespace::VERSION}" 
-        end
+        @if (!string.IsNullOrEmpty(Settings.PackageVersion))
+        {
+        @:sdk_information = "#{sdk_information}/@Settings.PackageVersion" 
+        }
         add_user_agent_information(sdk_information)
     end
   end


### PR DESCRIPTION
Removing version.rb file for azure sdk generation, updating telemetry to use package_version variable.
Addressing https://github.com/Azure/azure-sdk-for-ruby/issues/1042

Since we're not relying on the version file for azure sdk generation, we don't seem to need it anymore. We're creating an outer version of "version.rb" for the profile (not via autorest) which the gemspec file is referencing.
We will still need to pass the "package-version" to autorest commandline as a parameter, so telemetry can pick it up and add it to the specific api-version client user agent.

The add_telemetry method in the api-version client would look like the following if package-version=0.15.2:
```ruby
    def add_telemetry
        sdk_information = 'azure_mgmt_service_fabric'
        sdk_information = "#{sdk_information}/0.15.2"
        add_user_agent_information(sdk_information)
    end
```
here's how it looks before this change https://github.com/Azure/azure-sdk-for-ruby/blob/master/management/azure_mgmt_service_fabric/lib/2016-09-01/generated/azure_mgmt_service_fabric/service_fabric_management_client.rb#L129