### PR TITLE
Code changes to refactor serialization & desrialization.

### DIFF
--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -110,8 +110,8 @@ def @(Model.Name)_async(@(Model.MethodParameterDeclaration))
   @:request_headers['Content-Type'] = '@(Model.RequestContentType)'
   @EmptyLine
   @:# Serialize Request
-  @:@Model.ConstructRequestBodyMapper("request_mapper")
-  @:request_content = @(Model.ClientReference).serialize(request_mapper,  @(Model.RequestBody.Name))
+
+  @:@Model.ConstructRequestBodyContent("request_content")
   @:request_content = request_content != nil ? JSON.generate(request_content, quirks_mode: true) : nil
   @EmptyLine
 }

--- a/src/vanilla/Templates/ModelTemplate.cshtml
+++ b/src/vanilla/Templates/ModelTemplate.cshtml
@@ -22,6 +22,7 @@ module @(Settings.Namespace)
         }
       @EmptyLine
     }
+      include MsRest::JSONable
     
     @if (Model.BaseIsPolymorphic && Model.BaseModelType == null)
     {

--- a/test/vanilla/RspecTests/validation_spec.rb
+++ b/test/vanilla/RspecTests/validation_spec.rb
@@ -24,7 +24,7 @@ describe 'Validation Module' do
   it 'should work with constant in body' do
     product = ValidationModule::Models::Product.new
     product.child = Hash.new
-    result = @client.post_with_constant_in_body_async({ 'child' => {} }).value!
+    result = @client.post_with_constant_in_body_async(product).value!
     expect(result.response.status).to eq(200)
   end
 end


### PR DESCRIPTION
This PR is related to issue https://github.com/Azure/azure-sdk-for-ruby/issues/610. 

Original requirement for this task was to remove client from serialize and deserialize calls. @devigned created the base file [jsonable.rb](https://github.com/Azure/azure-sdk-for-ruby/blob/master/runtime/ms_rest/lib/ms_rest/jsonable.rb). 

Now, this PR takes care of combining jsonable changes with SDK generation. The modified Ruby SDK as a result of these code changes could be found at this [PR #1128](https://github.com/Azure/azure-sdk-for-ruby/pull/1128)