### PR TITLE
reference new testserver

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "shx": "^0.2.2",
     "through2-parallel": "^0.1.3",
     "yargs": "^8.0.2",
-    "@microsoft.azure/autorest.testserver": "1.9.2",
+    "@microsoft.azure/autorest.testserver": "2.3.9",
     "yarn": "^1.0.2"
   },
   "dependencies": {

--- a/test/vanilla/RspecTests/report_spec.rb
+++ b/test/vanilla/RspecTests/report_spec.rb
@@ -26,6 +26,6 @@ describe AutoRestReportService do
       end
     end
     puts "Test Coverage is #{count_of_calls}/#{count_of_methods}"
-    expect(count_of_calls/count_of_methods.to_f > 0.90).to be_truthy
+    expect(count_of_calls/count_of_methods.to_f > 0.85).to be_truthy
   end
 end


### PR DESCRIPTION
@veronicagg @sarangan12 FYI, it turns out the test server was lying in its coverage report. Some scenarios where *initialized* as being covered, with a comment saying "only supported in C#, ..., reactivate once other languages comply" - WTF, what is the point of a coverage report if you lie??? Whatever, I addressed that, as you can see your tests now fail because of missing coverage 😉

This is of course not your fault, but I thought you wanted to be aware of that. If you target the most recent test server (as this PR tries to do), you get [this](https://github.com/Azure/autorest.java/pull/38#issuecomment-344767962) goodness, so you will actually not loose anything if you temporarily tweak your tests to not expect >90% coverage (if I interpreted the CI logs correctly, that's what you do) - long term, you can add tests to get the coverage and then add that check back in. 🙂 

I'd be glad to assist with targeting the new test server, I wouldn't be too worried about getting 100% coverage ASAP for two reasons:
- obviously, only because the testserver suddenly complains now doesn't mean there's something wrong with your generator... probably just a few testcases missing
- maybe some of the tests the testserver *expects* you to do are actually bogus! I'll investigate that in the coming days, but I've already gotten rid of a set of tests that: tested for non-standard C#-specific behavior, but not even C# ran those tests, and then the testserver told *everyone* "yup, you ran that test".

I'll keep you posted about the details and improve the testserver experience in general. Where do you even find out what kind of REST calls you are supposed to make to get coverage? Correct, nowhere (or by looking at the testserver's source code).