### PR TITLE
Determine folder structure based on preview/stable folder

### DIFF
--- a/src/azure/CodeGeneratorRba.cs
+++ b/src/azure/CodeGeneratorRba.cs
@@ -49,7 +49,7 @@ namespace AutoRest.Ruby.Azure
             if (codeModel.ApiVersion == null){
                 throw new NullReferenceException("CodeModel doesn't have api-version set, specs in code model have mismatching api-versions.");
             }
-            generatedFolderName = Path.Combine(codeModel.ApiVersion, generatedFolderName);
+            generatedFolderName = Path.Combine(GeneratorSettingsRb.Instance.generatedFolderName, generatedFolderName);
             if (codeModel == null)
             {
                 throw new InvalidCastException("CodeModel is not a Azure Ruby code model.");

--- a/src/azure/Model/RequirementsRba.cs
+++ b/src/azure/Model/RequirementsRba.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using AutoRest.Core.Model;
 using AutoRest.Extensions.Azure;
 using AutoRest.Ruby.Model;
@@ -16,7 +17,7 @@ namespace AutoRest.Ruby.Azure.Model
         /// <summary>
         /// Name of the generated sub-folder inside output directory.
         /// </summary>
-        protected override string GeneratedFolderName { get { return this.CodeModel.ApiVersion + "/generated"; } }
+        protected override string GeneratedFolderName { get { return Path.Combine(GeneratorSettingsRb.Instance.generatedFolderName, "generated"); } }
         
         /// <summary>
         /// Checks whether model should be excluded from producing.

--- a/src/vanilla/GeneratorSettingsRb.cs
+++ b/src/vanilla/GeneratorSettingsRb.cs
@@ -77,5 +77,7 @@ namespace AutoRest.Ruby
         ///     Relative path to produced SDK files.
         /// </summary>
         public string sdkPath => packageName ?? sdkName;
+
+        public string generatedFolderName;
     }
 }


### PR DESCRIPTION
**Issue**
Let us take an example. Look at the [Microsoft.Authorization](https://github.com/Azure/azure-rest-api-specs/tree/12856c1900b518e9f4fa05cde6205218cafad17d/specification/authorization/resource-manager/Microsoft.Authorization) service.
The folder structure is:
    1. preview/2015-07-01
    2. stable/2015-07-01

Ideally, we would like the version under the preview to be 2015-07-01-preview. But, it is not a mandatory requirement. In this case, the version is mentioned [2015-07-01](https://github.com/Azure/azure-rest-api-specs/blob/12856c1900b518e9f4fa05cde6205218cafad17d/specification/authorization/resource-manager/Microsoft.Authorization/preview/2015-07-01/authorization.json#L5)
This creates issue in the Ruby SDK generation. The ruby SDK creates individual version folders under lib as:
    lib:
     +----- 2015-07-01
     +----- ......
     +----- ......

What is the problem? In the above scenario, since both have the same versions are 2015-07-01, one is overridden by the other. 

**Solution**
The folder structure should be based on the location of the file. In the above scenario, since one of them is under preview folder, the final SDK folder structure should be as:
    lib:
     +----- 2015-07-01
     +----- 2015-07-01-preview
     +----- ......

**Fix**
The code changes are complete in autorest.ruby in the [PR #25](https://github.com/Azure/autorest.ruby/pull/25). As a result of these code changes, there are changes in Azure SDK for Ruby. These code changes are available in the [PR #1281](https://github.com/Azure/azure-sdk-for-ruby/pull/1281). 

@olydis @salameer FYI.....
