### PR TITLE
Remove autorest.common reference from depedencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "yarn": "^1.0.2"
   },
   "dependencies": {
-    "@microsoft.azure/autorest.common": "git+https://github.com/azure/autorest.common.git",
     "dotnet-2.0.0": "^1.4.4"
   }
 }


### PR DESCRIPTION
The git submodule should be used -- using a dependency makes the package not installable.