### PR TITLE
Fix LongRunning operation bug by checking the value of the dictionary

### DIFF
--- a/src/azure/Model/MethodRba.cs
+++ b/src/azure/Model/MethodRba.cs
@@ -35,7 +35,7 @@ namespace AutoRest.Ruby.Azure.Model
         /// <summary>
         /// Returns true if method has x-ms-long-running-operation extension.
         /// </summary>
-        public bool IsLongRunningOperation => Extensions.ContainsKey(AzureExtensions.LongRunningExtension);
+        public bool IsLongRunningOperation => Extensions.ContainsKey(AzureExtensions.LongRunningExtension) && (bool) Extensions[AzureExtensions.LongRunningExtension];
 
         /// <summary>
         /// Returns true if method has x-ms-pageable extension.


### PR DESCRIPTION
Fix https://github.com/Azure/azure-sdk-for-ruby/issues/2723

The original logic just check the existence of the long running operation key. But the value could be false.
Instead of checking the value of the key, add the check for the value.