### PR TITLE
Get ApiVersion from input files path when ApiVersion is null

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using System.Threading.Tasks;
@@ -113,6 +114,23 @@ namespace AutoRest.Ruby
                 }
                 else
                 {
+                    if (codeModel.ApiVersion is null) {
+                        var pathItems = inputFileValue.FirstOrDefault()?.ToString().Split('/');
+                        foreach (var pathItem in pathItems) {
+                            if (pathItem.Length < 10) {
+                                continue;
+                            }
+                            DateTime dt;
+                            bool isValid = DateTime.TryParseExact(pathItem.Substring(0, 10), "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out dt);
+                            if (isValid) {
+                                codeModel.ApiVersion = pathItem;
+                                break;
+                            }
+                        }
+                    }
+                    if (codeModel.ApiVersion is null) {
+                        throw new NullReferenceException("codeModel.ApiVersion is null.");
+                    }
                     string generatedFolderName = (bool)(inputFileValue.FirstOrDefault()?.ToString().Contains("/preview/")) && !(versionExtensionRegex.IsMatch(codeModel.ApiVersion)) ? (codeModel.ApiVersion+"-preview"): codeModel.ApiVersion;
                     GeneratorSettingsRb.Instance.generatedFolderName = generatedFolderName;
                     plugin.CodeGenerator.Generate(codeModel).GetAwaiter().GetResult();


### PR DESCRIPTION
When `version` in the swagger file doesn't match version in the file path, the final `ApiVersion` in `codeModel` will be `null`. 
To fix this, I decided to get `apiVersion` from input files for this case. 

Example: 
https://github.com/Azure/azure-rest-api-specs/blob/695cbc9721ab5d90d0b45782e70a87d487a1eaf0/specification/mediaservices/resource-manager/Microsoft.Media/preview/2019-05-01-preview/AccountFilters.json#L6-L10